### PR TITLE
Add Tiptap rich text editor form type (TextEditorType)

### DIFF
--- a/assets/controllers/text_editor_controller.ts
+++ b/assets/controllers/text_editor_controller.ts
@@ -70,8 +70,8 @@ export default class extends Controller<HTMLElement> {
             onTransaction: () => this.refreshToolbar(),
         });
 
-        if (this.heightValue !== '') {
-            this.editorTarget.style.minHeight = this.heightValue;
+        if (this.heightValue !== '' && this.editor !== null) {
+            this.editor.view.dom.style.minHeight = this.heightValue;
         }
 
         // The textarea is now driven by the editor; hide it and let the server enforce "required".

--- a/assets/controllers/text_editor_controller.ts
+++ b/assets/controllers/text_editor_controller.ts
@@ -1,0 +1,166 @@
+import { Controller } from '@hotwired/stimulus';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import Link from '@tiptap/extension-link';
+import Placeholder from '@tiptap/extension-placeholder';
+
+interface CommandDefinition {
+    run: (editor: Editor) => void;
+    active: (editor: Editor) => boolean;
+}
+
+/**
+ * Behaviour for the platform TextEditorType.
+ *
+ * Mounts a Tiptap editor over the (now hidden) textarea, wires the server-rendered toolbar buttons to
+ * editor commands, and keeps the textarea value in sync so the form submits HTML or JSON. All output is
+ * re-sanitized server-side, so this controller only handles presentation and convenience.
+ */
+/* stimulusFetch: 'lazy' */
+export default class extends Controller<HTMLElement> {
+    static targets = ['input', 'editor', 'toolbar'];
+
+    static values = {
+        outputFormat: { type: String, default: 'html' },
+        placeholder: { type: String, default: '' },
+        height: { type: String, default: '' },
+    };
+
+    declare readonly inputTarget: HTMLTextAreaElement;
+    declare readonly editorTarget: HTMLElement;
+    declare readonly hasToolbarTarget: boolean;
+    declare readonly toolbarTarget: HTMLElement;
+    declare readonly outputFormatValue: string;
+    declare readonly placeholderValue: string;
+    declare readonly heightValue: string;
+
+    private editor: Editor | null = null;
+
+    private readonly commands: Record<string, CommandDefinition> = {
+        bold: { run: (e) => e.chain().focus().toggleBold().run(), active: (e) => e.isActive('bold') },
+        italic: { run: (e) => e.chain().focus().toggleItalic().run(), active: (e) => e.isActive('italic') },
+        strike: { run: (e) => e.chain().focus().toggleStrike().run(), active: (e) => e.isActive('strike') },
+        heading1: { run: (e) => e.chain().focus().toggleHeading({ level: 1 }).run(), active: (e) => e.isActive('heading', { level: 1 }) },
+        heading2: { run: (e) => e.chain().focus().toggleHeading({ level: 2 }).run(), active: (e) => e.isActive('heading', { level: 2 }) },
+        heading3: { run: (e) => e.chain().focus().toggleHeading({ level: 3 }).run(), active: (e) => e.isActive('heading', { level: 3 }) },
+        bulletList: { run: (e) => e.chain().focus().toggleBulletList().run(), active: (e) => e.isActive('bulletList') },
+        orderedList: { run: (e) => e.chain().focus().toggleOrderedList().run(), active: (e) => e.isActive('orderedList') },
+        blockquote: { run: (e) => e.chain().focus().toggleBlockquote().run(), active: (e) => e.isActive('blockquote') },
+        code: { run: (e) => e.chain().focus().toggleCode().run(), active: (e) => e.isActive('code') },
+        codeBlock: { run: (e) => e.chain().focus().toggleCodeBlock().run(), active: (e) => e.isActive('codeBlock') },
+        horizontalRule: { run: (e) => e.chain().focus().setHorizontalRule().run(), active: () => false },
+        link: { run: (e) => this.toggleLink(e), active: (e) => e.isActive('link') },
+        undo: { run: (e) => e.chain().focus().undo().run(), active: () => false },
+        redo: { run: (e) => e.chain().focus().redo().run(), active: () => false },
+    };
+
+    connect(): void {
+        const isJson = this.outputFormatValue === 'json';
+
+        this.editor = new Editor({
+            element: this.editorTarget,
+            extensions: [
+                // StarterKit (v2) bundles formatting, lists, blockquote, code, history, etc. but not Link.
+                StarterKit,
+                Link.configure({ openOnClick: false, autolink: true }),
+                Placeholder.configure({ placeholder: this.placeholderValue }),
+            ],
+            content: this.initialContent(isJson),
+            onUpdate: () => this.sync(),
+            onTransaction: () => this.refreshToolbar(),
+        });
+
+        if (this.heightValue !== '') {
+            this.editorTarget.style.minHeight = this.heightValue;
+        }
+
+        // The textarea is now driven by the editor; hide it and let the server enforce "required".
+        this.inputTarget.classList.add('d-none');
+        this.inputTarget.required = false;
+        this.inputTarget.setAttribute('aria-hidden', 'true');
+        this.inputTarget.tabIndex = -1;
+
+        this.refreshToolbar();
+    }
+
+    disconnect(): void {
+        this.editor?.destroy();
+        this.editor = null;
+    }
+
+    run(event: Event): void {
+        const button = (event.currentTarget as HTMLElement).closest<HTMLElement>('[data-editor-command]');
+        const command = button?.dataset.editorCommand;
+
+        if (this.editor === null || command === undefined || this.commands[command] === undefined) {
+            return;
+        }
+
+        this.commands[command].run(this.editor);
+    }
+
+    private initialContent(isJson: boolean): string | Record<string, unknown> {
+        const raw = this.inputTarget.value.trim();
+
+        if (raw === '') {
+            return '';
+        }
+
+        if (!isJson) {
+            return raw;
+        }
+
+        try {
+            return JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+            return '';
+        }
+    }
+
+    private sync(): void {
+        if (this.editor === null) {
+            return;
+        }
+
+        if (this.outputFormatValue === 'json') {
+            this.inputTarget.value = this.editor.isEmpty ? '' : JSON.stringify(this.editor.getJSON());
+        } else {
+            this.inputTarget.value = this.editor.isEmpty ? '' : this.editor.getHTML();
+        }
+
+        this.inputTarget.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    private refreshToolbar(): void {
+        if (this.editor === null || !this.hasToolbarTarget) {
+            return;
+        }
+
+        const editor = this.editor;
+
+        this.toolbarTarget.querySelectorAll<HTMLElement>('[data-editor-command]').forEach((button) => {
+            const command = button.dataset.editorCommand;
+
+            if (command !== undefined && this.commands[command] !== undefined) {
+                button.classList.toggle('active', this.commands[command].active(editor));
+            }
+        });
+    }
+
+    private toggleLink(editor: Editor): void {
+        const previous = (editor.getAttributes('link').href as string | undefined) ?? '';
+        const url = window.prompt('Enter a URL (leave empty to remove the link)', previous);
+
+        if (url === null) {
+            return;
+        }
+
+        if (url === '') {
+            editor.chain().focus().extendMarkRange('link').unsetLink().run();
+
+            return;
+        }
+
+        editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+    }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,6 +27,12 @@
         "webpackMode": "lazy",
         "fetch": "lazy",
         "enabled": true
+      },
+      "text-editor": {
+        "main": "controllers/text_editor_controller.ts",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       }
     },
     "importmap": {
@@ -53,6 +59,10 @@
     "@symfony/ux-chartjs": "^2.31.0",
     "@symfony/ux-autocomplete": "^2.31.0",
     "@tabler/core": "^1.4.0",
+    "@tiptap/core": "^2.11.5",
+    "@tiptap/extension-link": "^2.11.5",
+    "@tiptap/extension-placeholder": "^2.11.5",
+    "@tiptap/starter-kit": "^2.11.5",
     "bootstrap": "^5.3.8"
   },
   "devDependencies": {

--- a/assets/scss/_text-editor.scss
+++ b/assets/scss/_text-editor.scss
@@ -1,0 +1,88 @@
+// Rich text editor (TextEditorType) — styled to match Bootstrap/Tabler form controls.
+
+.swp-text-editor {
+    &__toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        padding: 0.375rem;
+        border: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color);
+        border-bottom: 0;
+        border-top-left-radius: var(--#{$prefix}border-radius);
+        border-top-right-radius: var(--#{$prefix}border-radius);
+        background-color: var(--#{$prefix}bg-surface-secondary, var(--#{$prefix}body-bg));
+    }
+
+    &__button {
+        --#{$prefix}btn-color: var(--#{$prefix}secondary);
+
+        &.active {
+            background-color: var(--#{$prefix}primary);
+            border-color: var(--#{$prefix}primary);
+            color: var(--#{$prefix}white, #fff);
+        }
+    }
+
+    &__content {
+        .ProseMirror {
+            min-height: 8rem;
+            padding: 0.5625rem 0.75rem;
+            border: var(--#{$prefix}border-width) solid var(--#{$prefix}border-color);
+            border-bottom-left-radius: var(--#{$prefix}border-radius);
+            border-bottom-right-radius: var(--#{$prefix}border-radius);
+            background-color: var(--#{$prefix}body-bg);
+            color: var(--#{$prefix}body-color);
+            overflow-y: auto;
+
+            &:focus {
+                outline: 0;
+                border-color: var(--#{$prefix}primary);
+                box-shadow: 0 0 0 0.25rem rgba(var(--#{$prefix}primary-rgb), 0.25);
+            }
+
+            > :first-child {
+                margin-top: 0;
+            }
+
+            > :last-child {
+                margin-bottom: 0;
+            }
+
+            // Placeholder shown when the editor is empty (from @tiptap/extension-placeholder).
+            p.is-editor-empty:first-child::before {
+                content: attr(data-placeholder);
+                float: left;
+                height: 0;
+                pointer-events: none;
+                color: var(--#{$prefix}secondary-color, var(--#{$prefix}secondary));
+            }
+
+            blockquote {
+                padding-left: 1rem;
+                border-left: 3px solid var(--#{$prefix}border-color);
+                color: var(--#{$prefix}secondary-color, var(--#{$prefix}secondary));
+            }
+
+            code {
+                padding: 0.125rem 0.25rem;
+                border-radius: var(--#{$prefix}border-radius-sm);
+                background-color: var(--#{$prefix}bg-surface-secondary, rgba(0, 0, 0, 0.05));
+                font-size: 0.875em;
+            }
+
+            pre {
+                padding: 0.75rem 1rem;
+                border-radius: var(--#{$prefix}border-radius);
+                background-color: var(--#{$prefix}dark, #1a1d21);
+                color: var(--#{$prefix}light, #f8f9fa);
+                overflow-x: auto;
+
+                code {
+                    padding: 0;
+                    background: none;
+                    color: inherit;
+                }
+            }
+        }
+    }
+}

--- a/assets/scss/platform.scss
+++ b/assets/scss/platform.scss
@@ -11,3 +11,4 @@ $enable-deprecation-messages: false !default;
 @import '@tabler/core';
 @import '@tabler/core/scss/vendor/tom-select';
 @import './styles';
+@import './text-editor';

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/event-dispatcher": "^7.2",
         "symfony/form": "^7.3",
         "symfony/framework-bundle": "^7.2",
+        "symfony/html-sanitizer": "^7.2",
         "symfony/http-client": "^7.2",
         "symfony/http-kernel": "^7.2",
         "symfony/property-access": "^7.2",

--- a/docs/form-types/index.md
+++ b/docs/form-types/index.md
@@ -1,0 +1,7 @@
+# Form Types
+
+The platform ships a small set of opinionated, reusable Symfony form types that any application can use.
+
+## Contents
+
+- [TextEditorType](./text-editor.md) — a Tiptap-powered rich text editor with server-side HTML sanitization.

--- a/docs/form-types/text-editor.md
+++ b/docs/form-types/text-editor.md
@@ -1,0 +1,120 @@
+# TextEditorType
+
+**Class:** `SolidWorx\Platform\PlatformBundle\Form\Type\TextEditorType`
+**Parent type:** `Symfony\Component\Form\Extension\Core\Type\TextareaType`
+**Stores:** sanitized HTML string (default) or a validated Tiptap JSON document
+
+## Overview
+
+`TextEditorType` progressively enhances a standard `<textarea>` into a rich text editor powered by
+[Tiptap](https://tiptap.dev/). It is deliberately opinionated: you get a curated toolbar, sensible
+defaults, and a secure pipeline out of the box, with a few options to tune behaviour.
+
+Key properties:
+
+- **Graceful degradation** — a real `<textarea>` is always rendered, so the field still works without JavaScript.
+- **Secure by default** — every submission is re-sanitized on the server. Whatever the browser sends is
+  filtered down to the allow-list for the configured toolbar, so scripts, event handlers and unsafe URL
+  schemes can never be persisted. Client-side behaviour is never trusted.
+- **Auto-registered** — the form type and its sanitizer are wired automatically by `PlatformBundle`.
+
+## Requirements
+
+The HTML sanitizer component must be installed (a dependency of the bundle):
+
+```bash
+composer require symfony/html-sanitizer
+```
+
+The frontend assets must be built so the Stimulus controller and styles are available:
+
+```bash
+cd assets
+bun install
+bun run build
+```
+
+The widget is rendered by the platform form theme. Register it once in your Twig configuration so the
+editor markup is applied (without it, the field gracefully falls back to a plain textarea):
+
+```yaml
+# config/packages/twig.yaml
+twig:
+    form_themes:
+        - '@Platform/Form/theme.html.twig'
+```
+
+## Usage
+
+```php
+use SolidWorx\Platform\PlatformBundle\Form\Type\TextEditorType;
+
+$builder->add('body', TextEditorType::class, [
+    'label' => 'Description',
+    'required' => false,
+]);
+```
+
+That's it — the field renders the editor with the default toolbar and stores sanitized HTML in the
+mapped property (a plain `string`).
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `output_format` | `'html'` \| `'json'` | `'html'` | Store sanitized HTML, or a Tiptap (ProseMirror) JSON document. |
+| `json_as_array` | `bool` | `false` | Only for `output_format: 'json'`. When `true`, the model value is a decoded PHP `array`; when `false`, it stays a JSON `string` (DB/column friendly). |
+| `toolbar` | `'minimal'` \| `'default'` \| `'full'` | `'default'` | Toolbar preset. Drives both the buttons shown and the sanitization allow-list. |
+| `allowed_tags` | `string[]` \| `null` | `null` | Override the HTML tags permitted by the sanitizer (HTML mode only). |
+| `sanitizer` | `HtmlSanitizerInterface` \| `null` | `null` | Provide your own configured sanitizer instead of the platform default (HTML mode only). |
+| `placeholder` | `string` \| `null` | `null` | Placeholder text shown when the editor is empty. |
+| `editor_height` | `string` \| `null` | `null` | Minimum editor height as a CSS value, e.g. `'20rem'`. |
+
+### Toolbar presets
+
+| Preset | Features |
+|--------|----------|
+| `minimal` | bold, italic, link |
+| `default` | headings (H2–H3), bold, italic, strikethrough, bullet/numbered lists, quote, inline code, link, undo/redo |
+| `full` | everything in `default` plus H1, code block and horizontal rule |
+
+## Choosing an output format
+
+```php
+// Sanitized HTML (default) — maps to a string property/column.
+$builder->add('body', TextEditorType::class);
+
+// Tiptap JSON stored as a string — maps to a TEXT/JSON column you decode yourself.
+$builder->add('body', TextEditorType::class, [
+    'output_format' => 'json',
+]);
+
+// Tiptap JSON decoded to a PHP array — maps to a Doctrine `json` column.
+$builder->add('body', TextEditorType::class, [
+    'output_format' => 'json',
+    'json_as_array' => true,
+]);
+```
+
+JSON is useful when you need structured content for custom extensions or rendering pipelines. In JSON
+mode the submitted document is validated against the toolbar's allowed nodes and marks, and unsafe link
+URLs are stripped.
+
+## Rendering the output
+
+For HTML output, the stored value is already sanitized, so it is safe to print with the `raw` filter:
+
+```twig
+<div class="content">{{ product.body|raw }}</div>
+```
+
+For JSON output, render it with your own renderer (e.g. a Tiptap/ProseMirror-to-HTML converter); the
+JSON itself is not HTML and must not be printed directly.
+
+## Security notes
+
+- Sanitization happens in a Symfony form data transformer, i.e. on the server, independent of the
+  editor. Posting hand-crafted payloads that bypass the JavaScript editor cannot inject unsafe markup.
+- Links are restricted to the `http`, `https` and `mailto` schemes and are forced to carry
+  `rel="noopener noreferrer"`.
+- Narrow the allow-list further per field with `allowed_tags`, or pass a fully custom `sanitizer`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Welcome to the SolidWorx Platform documentation. This platform provides the foun
 - [Configuration](./configuration/index.md)
 - [Authentication & Security](./security/index.md) — default form login and two-factor authentication
 - [Doctrine Types](./doctrine-types/index.md)
+- [Form Types](./form-types/index.md) — reusable form types, including the rich text editor
 - [Rector Rules](./rector-rules/index.md)
 
 ## Upgrading

--- a/src/Bundle/Platform/Form/DataTransformer/JsonDocumentTransformer.php
+++ b/src/Bundle/Platform/Form/DataTransformer/JsonDocumentTransformer.php
@@ -134,11 +134,19 @@ final readonly class JsonDocumentTransformer implements DataTransformerInterface
             }
         }
 
-        if (isset($node['marks']) && is_array($node['marks'])) {
+        if (\array_key_exists('marks', $node)) {
+            if (! is_array($node['marks'])) {
+                throw new TransformationFailedException('Invalid marks.');
+            }
+
             $node['marks'] = $this->sanitizeMarks($node['marks']);
         }
 
-        if (isset($node['content']) && is_array($node['content'])) {
+        if (\array_key_exists('content', $node)) {
+            if (! is_array($node['content'])) {
+                throw new TransformationFailedException('Invalid node content.');
+            }
+
             $node['content'] = array_values(array_map(
                 function (mixed $child): array {
                     if (! is_array($child)) {

--- a/src/Bundle/Platform/Form/DataTransformer/JsonDocumentTransformer.php
+++ b/src/Bundle/Platform/Form/DataTransformer/JsonDocumentTransformer.php
@@ -200,6 +200,12 @@ final readonly class JsonDocumentTransformer implements DataTransformerInterface
 
     private function isSafeUrl(string $url): bool
     {
+        $url = trim($url);
+
+        if (str_starts_with($url, '//')) {
+            return false;
+        }
+
         $scheme = parse_url($url, PHP_URL_SCHEME);
 
         if (! is_string($scheme)) {

--- a/src/Bundle/Platform/Form/DataTransformer/JsonDocumentTransformer.php
+++ b/src/Bundle/Platform/Form/DataTransformer/JsonDocumentTransformer.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\PlatformBundle\Form\DataTransformer;
+
+use JsonException;
+use Override;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+use function in_array;
+use function is_array;
+use function is_string;
+use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Validates and sanitizes a Tiptap (ProseMirror) JSON document.
+ *
+ * The submitted document is rejected unless every node and mark type is part of the toolbar's allow-list,
+ * and link marks are stripped of unsafe URL schemes. This keeps JSON output as secure as the HTML path.
+ *
+ * @implements DataTransformerInterface<array<array-key, mixed>|string, string>
+ */
+final readonly class JsonDocumentTransformer implements DataTransformerInterface
+{
+    private const array SAFE_LINK_SCHEMES = ['http', 'https', 'mailto'];
+
+    /**
+     * @param list<string> $allowedNodes
+     * @param list<string> $allowedMarks
+     * @param list<int>    $allowedHeadingLevels
+     */
+    public function __construct(
+        private array $allowedNodes,
+        private array $allowedMarks,
+        private array $allowedHeadingLevels,
+        private bool $asArray,
+    ) {
+    }
+
+    #[Override]
+    public function transform(mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            try {
+                return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            } catch (JsonException $exception) {
+                throw new TransformationFailedException('Unable to encode the document.', 0, $exception);
+            }
+        }
+
+        throw new TransformationFailedException('Expected an array or JSON string.');
+    }
+
+    /**
+     * @return array<array-key, mixed>|string|null
+     */
+    #[Override]
+    public function reverseTransform(mixed $value): array | string | null
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (! is_string($value)) {
+            throw new TransformationFailedException('Expected a JSON string.');
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new TransformationFailedException('Invalid JSON document.', 0, $exception);
+        }
+
+        if (! is_array($decoded)) {
+            throw new TransformationFailedException('Invalid document structure.');
+        }
+
+        $clean = $this->sanitizeNode($decoded);
+
+        if ($this->asArray) {
+            return $clean;
+        }
+
+        try {
+            return json_encode($clean, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException $exception) {
+            throw new TransformationFailedException('Unable to encode the document.', 0, $exception);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     *
+     * @return array<array-key, mixed>
+     */
+    private function sanitizeNode(array $node): array
+    {
+        $type = $node['type'] ?? null;
+
+        if (! is_string($type) || ! in_array($type, $this->allowedNodes, true)) {
+            throw new TransformationFailedException(sprintf('Disallowed node type "%s".', is_string($type) ? $type : get_debug_type($type)));
+        }
+
+        if ($type === 'heading') {
+            $attrs = $node['attrs'] ?? null;
+            $level = is_array($attrs) ? ($attrs['level'] ?? null) : null;
+
+            if (! in_array($level, $this->allowedHeadingLevels, true)) {
+                throw new TransformationFailedException('Disallowed heading level.');
+            }
+        }
+
+        if (isset($node['marks']) && is_array($node['marks'])) {
+            $node['marks'] = $this->sanitizeMarks($node['marks']);
+        }
+
+        if (isset($node['content']) && is_array($node['content'])) {
+            $node['content'] = array_values(array_map(
+                function (mixed $child): array {
+                    if (! is_array($child)) {
+                        throw new TransformationFailedException('Invalid node.');
+                    }
+
+                    return $this->sanitizeNode($child);
+                },
+                $node['content'],
+            ));
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<array-key, mixed> $marks
+     *
+     * @return list<array<array-key, mixed>>
+     */
+    private function sanitizeMarks(array $marks): array
+    {
+        $clean = [];
+
+        foreach ($marks as $mark) {
+            if (! is_array($mark)) {
+                throw new TransformationFailedException('Invalid mark.');
+            }
+
+            $type = $mark['type'] ?? null;
+
+            if (! is_string($type) || ! in_array($type, $this->allowedMarks, true)) {
+                throw new TransformationFailedException(sprintf('Disallowed mark type "%s".', is_string($type) ? $type : get_debug_type($type)));
+            }
+
+            if ($type === 'link') {
+                $attrs = $mark['attrs'] ?? null;
+
+                if (! is_array($attrs)) {
+                    continue;
+                }
+
+                $href = $attrs['href'] ?? null;
+
+                if (! is_string($href) || ! $this->isSafeUrl($href)) {
+                    // Drop the unsafe link but keep the text content intact.
+                    continue;
+                }
+
+                $attrs['rel'] = 'noopener noreferrer';
+                $mark['attrs'] = $attrs;
+            }
+
+            $clean[] = $mark;
+        }
+
+        return $clean;
+    }
+
+    private function isSafeUrl(string $url): bool
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        if (! is_string($scheme)) {
+            // Relative URLs (no scheme) are safe.
+            return true;
+        }
+
+        return in_array(strtolower($scheme), self::SAFE_LINK_SCHEMES, true);
+    }
+}

--- a/src/Bundle/Platform/Form/DataTransformer/SanitizeHtmlTransformer.php
+++ b/src/Bundle/Platform/Form/DataTransformer/SanitizeHtmlTransformer.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\PlatformBundle\Form\DataTransformer;
+
+use Override;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+
+use function is_string;
+
+/**
+ * Sanitizes submitted rich text HTML against a configured allow-list.
+ *
+ * @implements DataTransformerInterface<string, string>
+ */
+final readonly class SanitizeHtmlTransformer implements DataTransformerInterface
+{
+    public function __construct(
+        private HtmlSanitizerInterface $sanitizer,
+    ) {
+    }
+
+    #[Override]
+    public function transform(mixed $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (! is_string($value)) {
+            throw new TransformationFailedException('Expected a string.');
+        }
+
+        return $value;
+    }
+
+    #[Override]
+    public function reverseTransform(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (! is_string($value)) {
+            throw new TransformationFailedException('Expected a string.');
+        }
+
+        $sanitized = trim($this->sanitizer->sanitize($value));
+
+        return $sanitized === '' ? null : $sanitized;
+    }
+}

--- a/src/Bundle/Platform/Form/TextEditor/HtmlSanitizerFactory.php
+++ b/src/Bundle/Platform/Form/TextEditor/HtmlSanitizerFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\PlatformBundle\Form\TextEditor;
+
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+/**
+ * Builds an opinionated {@see HtmlSanitizer} tailored to a set of allowed elements.
+ *
+ * Sanitization is the security boundary for the rich text editor: whatever the browser submits is
+ * filtered down to this allow-list on the server, so a tampered or malicious payload can never persist
+ * scripts, event handlers or unsafe URL schemes.
+ */
+final class HtmlSanitizerFactory
+{
+    /**
+     * @param list<string> $allowedElements
+     */
+    public function create(array $allowedElements): HtmlSanitizer
+    {
+        $config = (new HtmlSanitizerConfig())
+            ->allowLinkSchemes(['https', 'http', 'mailto'])
+            ->forceAttribute('a', 'rel', 'noopener noreferrer');
+
+        foreach ($allowedElements as $element) {
+            $config = $config->allowElement($element, $element === 'a' ? ['href'] : []);
+        }
+
+        return new HtmlSanitizer($config);
+    }
+}

--- a/src/Bundle/Platform/Form/TextEditor/ToolbarPreset.php
+++ b/src/Bundle/Platform/Form/TextEditor/ToolbarPreset.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\PlatformBundle\Form\TextEditor;
+
+/**
+ * Opinionated toolbar presets for the {@see \SolidWorx\Platform\PlatformBundle\Form\Type\TextEditorType}.
+ *
+ * Each preset maps to an ordered list of editor features. The same preset drives both the client-side
+ * toolbar (which buttons to render) and the server-side sanitization allow-lists (which HTML tags and
+ * ProseMirror nodes/marks are permitted), so the two can never drift apart.
+ */
+enum ToolbarPreset: string
+{
+    case Minimal = 'minimal';
+    case Default = 'default';
+    case Full = 'full';
+
+    /**
+     * Maps an editor feature to the HTML tags it may produce.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array FEATURE_TAGS = [
+        'bold' => ['strong'],
+        'italic' => ['em'],
+        'strike' => ['s'],
+        'heading1' => ['h1'],
+        'heading2' => ['h2'],
+        'heading3' => ['h3'],
+        'bulletList' => ['ul', 'li'],
+        'orderedList' => ['ol', 'li'],
+        'blockquote' => ['blockquote'],
+        'code' => ['code'],
+        'codeBlock' => ['pre', 'code'],
+        'horizontalRule' => ['hr'],
+        'link' => ['a'],
+        'undo' => [],
+        'redo' => [],
+    ];
+
+    /**
+     * Maps an editor feature to the ProseMirror node types it may produce.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array FEATURE_NODES = [
+        'heading1' => ['heading'],
+        'heading2' => ['heading'],
+        'heading3' => ['heading'],
+        'bulletList' => ['bulletList', 'listItem'],
+        'orderedList' => ['orderedList', 'listItem'],
+        'blockquote' => ['blockquote'],
+        'codeBlock' => ['codeBlock'],
+        'horizontalRule' => ['horizontalRule'],
+    ];
+
+    /**
+     * Maps an editor feature to the ProseMirror mark types it may produce.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array FEATURE_MARKS = [
+        'bold' => ['bold'],
+        'italic' => ['italic'],
+        'strike' => ['strike'],
+        'code' => ['code'],
+        'link' => ['link'],
+    ];
+
+    /**
+     * The ordered list of toolbar features enabled for this preset.
+     *
+     * @return list<string>
+     */
+    public function features(): array
+    {
+        return match ($this) {
+            self::Minimal => ['bold', 'italic', 'link'],
+            self::Default => [
+                'heading2', 'heading3',
+                'bold', 'italic', 'strike',
+                'bulletList', 'orderedList', 'blockquote', 'code',
+                'link',
+                'undo', 'redo',
+            ],
+            self::Full => [
+                'heading1', 'heading2', 'heading3',
+                'bold', 'italic', 'strike',
+                'bulletList', 'orderedList', 'blockquote', 'code', 'codeBlock',
+                'horizontalRule', 'link',
+                'undo', 'redo',
+            ],
+        };
+    }
+
+    /**
+     * The HTML tags permitted when storing the editor output as sanitized HTML.
+     *
+     * @return list<string>
+     */
+    public function allowedTags(): array
+    {
+        return $this->collect(self::FEATURE_TAGS, ['p', 'br']);
+    }
+
+    /**
+     * The ProseMirror node types permitted when storing the editor output as JSON.
+     *
+     * @return list<string>
+     */
+    public function allowedNodes(): array
+    {
+        return $this->collect(self::FEATURE_NODES, ['doc', 'paragraph', 'text', 'hardBreak']);
+    }
+
+    /**
+     * The ProseMirror mark types permitted when storing the editor output as JSON.
+     *
+     * @return list<string>
+     */
+    public function allowedMarks(): array
+    {
+        return $this->collect(self::FEATURE_MARKS, []);
+    }
+
+    /**
+     * The heading levels permitted for this preset.
+     *
+     * @return list<int>
+     */
+    public function allowedHeadingLevels(): array
+    {
+        $levels = [];
+
+        foreach ($this->features() as $feature) {
+            if (preg_match('/^heading([1-6])$/', $feature, $matches) === 1) {
+                $levels[] = (int) $matches[1];
+            }
+        }
+
+        return $levels;
+    }
+
+    /**
+     * @param array<string, list<string>> $map
+     * @param list<string>                 $base
+     *
+     * @return list<string>
+     */
+    private function collect(array $map, array $base): array
+    {
+        $values = $base;
+
+        foreach ($this->features() as $feature) {
+            foreach ($map[$feature] ?? [] as $value) {
+                $values[] = $value;
+            }
+        }
+
+        return array_values(array_unique($values));
+    }
+}

--- a/src/Bundle/Platform/Form/Type/TextEditorType.php
+++ b/src/Bundle/Platform/Form/Type/TextEditorType.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\PlatformBundle\Form\Type;
+
+use Override;
+use SolidWorx\Platform\PlatformBundle\Form\DataTransformer\JsonDocumentTransformer;
+use SolidWorx\Platform\PlatformBundle\Form\DataTransformer\SanitizeHtmlTransformer;
+use SolidWorx\Platform\PlatformBundle\Form\TextEditor\HtmlSanitizerFactory;
+use SolidWorx\Platform\PlatformBundle\Form\TextEditor\ToolbarPreset;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+use function is_array;
+use function is_string;
+
+/**
+ * A Tiptap-powered rich text editor that progressively enhances a standard textarea.
+ *
+ * The field always renders a real `<textarea>` (so it degrades gracefully without JavaScript) and stores
+ * either sanitized HTML (default) or a validated Tiptap JSON document. All output is filtered server-side,
+ * which is the security boundary regardless of what the browser submits.
+ */
+final class TextEditorType extends AbstractType
+{
+    public function __construct(
+        private readonly HtmlSanitizerFactory $sanitizerFactory,
+    ) {
+    }
+
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $preset = $this->resolvePreset($options['toolbar']);
+
+        if ($options['output_format'] === 'json') {
+            $builder->addModelTransformer(new JsonDocumentTransformer(
+                $preset->allowedNodes(),
+                $preset->allowedMarks(),
+                $preset->allowedHeadingLevels(),
+                $options['json_as_array'] === true,
+            ));
+
+            return;
+        }
+
+        $sanitizer = $options['sanitizer'];
+
+        if (! $sanitizer instanceof HtmlSanitizerInterface) {
+            $allowedTags = $options['allowed_tags'];
+            $sanitizer = $this->sanitizerFactory->create(
+                is_array($allowedTags) ? array_values(array_filter($allowedTags, is_string(...))) : $preset->allowedTags(),
+            );
+        }
+
+        $builder->addModelTransformer(new SanitizeHtmlTransformer($sanitizer));
+    }
+
+    #[Override]
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $preset = $this->resolvePreset($options['toolbar']);
+
+        $view->vars['output_format'] = $options['output_format'];
+        $view->vars['toolbar'] = $preset->features();
+        $view->vars['editor_placeholder'] = $options['placeholder'] ?? '';
+        $view->vars['editor_height'] = $options['editor_height'] ?? '';
+    }
+
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'output_format' => 'html',
+            'json_as_array' => false,
+            'toolbar' => ToolbarPreset::Default->value,
+            'allowed_tags' => null,
+            'sanitizer' => null,
+            'placeholder' => null,
+            'editor_height' => null,
+        ]);
+
+        $resolver->setAllowedValues('output_format', ['html', 'json']);
+        $resolver->setAllowedValues('toolbar', array_map(static fn (ToolbarPreset $preset): string => $preset->value, ToolbarPreset::cases()));
+        $resolver->setAllowedTypes('json_as_array', 'bool');
+        $resolver->setAllowedTypes('allowed_tags', ['null', 'string[]']);
+        $resolver->setAllowedTypes('sanitizer', ['null', HtmlSanitizerInterface::class]);
+        $resolver->setAllowedTypes('placeholder', ['null', 'string']);
+        $resolver->setAllowedTypes('editor_height', ['null', 'string']);
+    }
+
+    private function resolvePreset(mixed $toolbar): ToolbarPreset
+    {
+        return ToolbarPreset::from(is_string($toolbar) ? $toolbar : ToolbarPreset::Default->value);
+    }
+
+    #[Override]
+    public function getParent(): string
+    {
+        return TextareaType::class;
+    }
+
+    #[Override]
+    public function getBlockPrefix(): string
+    {
+        return 'text_editor';
+    }
+}

--- a/src/Bundle/Platform/Resources/views/Form/theme.html.twig
+++ b/src/Bundle/Platform/Resources/views/Form/theme.html.twig
@@ -72,3 +72,49 @@
         {{- parent() -}}
     </div>
 {%- endblock password_widget %}
+
+{% block text_editor_widget -%}
+    {%- set editor_controller = '@solidworx/platform/text-editor' -%}
+    {%- set toolbar_buttons = {
+        bold: { icon: 'tabler:bold', label: 'Bold' },
+        italic: { icon: 'tabler:italic', label: 'Italic' },
+        strike: { icon: 'tabler:strikethrough', label: 'Strikethrough' },
+        heading1: { icon: 'tabler:h-1', label: 'Heading 1' },
+        heading2: { icon: 'tabler:h-2', label: 'Heading 2' },
+        heading3: { icon: 'tabler:h-3', label: 'Heading 3' },
+        bulletList: { icon: 'tabler:list', label: 'Bullet list' },
+        orderedList: { icon: 'tabler:list-numbers', label: 'Numbered list' },
+        blockquote: { icon: 'tabler:blockquote', label: 'Quote' },
+        code: { icon: 'tabler:code', label: 'Inline code' },
+        codeBlock: { icon: 'tabler:source-code', label: 'Code block' },
+        horizontalRule: { icon: 'tabler:separator-horizontal', label: 'Divider' },
+        link: { icon: 'tabler:link', label: 'Link' },
+        undo: { icon: 'tabler:arrow-back-up', label: 'Undo' },
+        redo: { icon: 'tabler:arrow-forward-up', label: 'Redo' },
+    } -%}
+    <div class="swp-text-editor"
+        {{ stimulus_controller(editor_controller, {
+            outputFormat: output_format,
+            placeholder: editor_placeholder,
+            height: editor_height,
+        }) }}
+    >
+        <div class="swp-text-editor__toolbar btn-toolbar" role="toolbar" aria-label="Formatting"
+            {{ stimulus_target(editor_controller, 'toolbar') }}
+        >
+            {%- for feature in toolbar -%}
+                {%- set button = toolbar_buttons[feature] | default(null) -%}
+                {%- if button is not null -%}
+                    <button type="button" class="btn btn-sm btn-icon swp-text-editor__button"
+                        data-editor-command="{{ feature }}"
+                        title="{{ button.label }}"
+                        aria-label="{{ button.label }}"
+                        {{ stimulus_action(editor_controller, 'run') }}
+                    >{{ ux_icon(button.icon) }}</button>
+                {%- endif -%}
+            {%- endfor -%}
+        </div>
+        <div class="swp-text-editor__content" {{ stimulus_target(editor_controller, 'editor') }}></div>
+        <textarea {{ block('widget_attributes') }} {{ stimulus_target(editor_controller, 'input') }}>{{ value }}</textarea>
+    </div>
+{%- endblock text_editor_widget %}

--- a/tests/Bundle/PlatformBundle/Form/TextEditor/ToolbarPresetTest.php
+++ b/tests/Bundle/PlatformBundle/Form/TextEditor/ToolbarPresetTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\Tests\Bundle\PlatformBundle\Form\TextEditor;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidWorx\Platform\PlatformBundle\Form\TextEditor\ToolbarPreset;
+
+#[CoversClass(ToolbarPreset::class)]
+final class ToolbarPresetTest extends TestCase
+{
+    public function testMinimalPresetFeatures(): void
+    {
+        self::assertSame(['bold', 'italic', 'link'], ToolbarPreset::Minimal->features());
+    }
+
+    public function testAllowedTagsTrackEnabledFeatures(): void
+    {
+        $tags = ToolbarPreset::Minimal->allowedTags();
+
+        self::assertContains('strong', $tags);
+        self::assertContains('em', $tags);
+        self::assertContains('a', $tags);
+        self::assertContains('p', $tags);
+        // Headings are not part of the minimal preset.
+        self::assertNotContains('h1', $tags);
+        self::assertNotContains('h2', $tags);
+    }
+
+    public function testFullPresetAllowsHeadingsAndCodeBlocks(): void
+    {
+        $tags = ToolbarPreset::Full->allowedTags();
+
+        self::assertContains('h1', $tags);
+        self::assertContains('pre', $tags);
+        self::assertContains('hr', $tags);
+    }
+
+    public function testAllowedTagsAreUnique(): void
+    {
+        $tags = ToolbarPreset::Full->allowedTags();
+
+        self::assertSame(array_values(array_unique($tags)), $tags);
+    }
+
+    public function testAllowedNodesAlwaysIncludeTheBaseDocument(): void
+    {
+        $nodes = ToolbarPreset::Minimal->allowedNodes();
+
+        self::assertContains('doc', $nodes);
+        self::assertContains('paragraph', $nodes);
+        self::assertContains('text', $nodes);
+    }
+
+    public function testAllowedMarksTrackEnabledFeatures(): void
+    {
+        self::assertSame(['bold', 'italic', 'link'], ToolbarPreset::Minimal->allowedMarks());
+    }
+
+    public function testAllowedHeadingLevels(): void
+    {
+        self::assertSame([], ToolbarPreset::Minimal->allowedHeadingLevels());
+        self::assertSame([2, 3], ToolbarPreset::Default->allowedHeadingLevels());
+        self::assertSame([1, 2, 3], ToolbarPreset::Full->allowedHeadingLevels());
+    }
+}

--- a/tests/Bundle/PlatformBundle/Form/Type/TextEditorTypeTest.php
+++ b/tests/Bundle/PlatformBundle/Form/Type/TextEditorTypeTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\Tests\Bundle\PlatformBundle\Form\Type;
+
+use Override;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SolidWorx\Platform\PlatformBundle\Form\DataTransformer\JsonDocumentTransformer;
+use SolidWorx\Platform\PlatformBundle\Form\DataTransformer\SanitizeHtmlTransformer;
+use SolidWorx\Platform\PlatformBundle\Form\TextEditor\HtmlSanitizerFactory;
+use SolidWorx\Platform\PlatformBundle\Form\TextEditor\ToolbarPreset;
+use SolidWorx\Platform\PlatformBundle\Form\Type\TextEditorType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+
+#[CoversClass(TextEditorType::class)]
+#[CoversClass(SanitizeHtmlTransformer::class)]
+#[CoversClass(JsonDocumentTransformer::class)]
+#[CoversClass(HtmlSanitizerFactory::class)]
+#[CoversClass(ToolbarPreset::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class TextEditorTypeTest extends TypeTestCase
+{
+    #[Override]
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension([
+                new TextEditorType(new HtmlSanitizerFactory()),
+            ], []),
+        ];
+    }
+
+    public function testItIsBuiltOnTopOfATextarea(): void
+    {
+        $view = $this->factory->create(TextEditorType::class)->createView();
+        $blockPrefixes = $view->vars['block_prefixes'];
+
+        self::assertIsArray($blockPrefixes);
+        self::assertContains('textarea', $blockPrefixes);
+        self::assertContains('text_editor', $blockPrefixes);
+    }
+
+    public function testItExposesToolbarConfigurationToTheView(): void
+    {
+        $view = $this->factory->create(TextEditorType::class, null, [
+            'toolbar' => 'minimal',
+            'placeholder' => 'Start typing…',
+            'editor_height' => '20rem',
+        ])->createView();
+
+        self::assertSame('html', $view->vars['output_format']);
+        self::assertSame(['bold', 'italic', 'link'], $view->vars['toolbar']);
+        self::assertSame('Start typing…', $view->vars['editor_placeholder']);
+        self::assertSame('20rem', $view->vars['editor_height']);
+    }
+
+    public function testItKeepsAllowedFormattingHtml(): void
+    {
+        $form = $this->factory->create(TextEditorType::class);
+        $form->submit('<p>Hello <strong>bold</strong> and <em>italic</em></p>');
+
+        self::assertTrue($form->isSynchronized());
+        self::assertIsString($form->getData());
+        self::assertStringContainsString('<strong>bold</strong>', $form->getData());
+        self::assertStringContainsString('<em>italic</em>', $form->getData());
+    }
+
+    public function testItStripsDangerousHtmlOnTheServer(): void
+    {
+        $form = $this->factory->create(TextEditorType::class);
+        $form->submit('<p>safe</p><script>alert(1)</script><img src=x onerror="alert(1)">');
+
+        self::assertTrue($form->isSynchronized());
+        self::assertIsString($form->getData());
+        self::assertStringContainsString('safe', $form->getData());
+        self::assertStringNotContainsString('<script', $form->getData());
+        self::assertStringNotContainsString('onerror', $form->getData());
+        self::assertStringNotContainsString('<img', $form->getData());
+    }
+
+    public function testItStripsUnsafeLinkSchemes(): void
+    {
+        $form = $this->factory->create(TextEditorType::class);
+        $form->submit('<p><a href="javascript:alert(1)">click</a></p>');
+
+        self::assertTrue($form->isSynchronized());
+        self::assertIsString($form->getData());
+        self::assertStringContainsString('click', $form->getData());
+        self::assertStringNotContainsString('javascript', $form->getData());
+    }
+
+    public function testEmptyHtmlBecomesNull(): void
+    {
+        $form = $this->factory->create(TextEditorType::class);
+        $form->submit('');
+
+        self::assertTrue($form->isSynchronized());
+        self::assertNull($form->getData());
+    }
+
+    public function testJsonOutputIsStoredAsStringByDefault(): void
+    {
+        $document = $this->paragraph('Hello world');
+
+        $form = $this->factory->create(TextEditorType::class, null, ['output_format' => 'json']);
+        $form->submit((string) json_encode($document));
+
+        self::assertTrue($form->isSynchronized());
+        self::assertIsString($form->getData());
+        self::assertSame($document, json_decode($form->getData(), true));
+    }
+
+    public function testJsonOutputCanBeDecodedToAnArray(): void
+    {
+        $document = $this->paragraph('Hello world');
+
+        $form = $this->factory->create(TextEditorType::class, null, [
+            'output_format' => 'json',
+            'json_as_array' => true,
+        ]);
+        $form->submit((string) json_encode($document));
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame($document, $form->getData());
+    }
+
+    public function testJsonRejectsDisallowedNodeTypes(): void
+    {
+        $form = $this->factory->create(TextEditorType::class, null, ['output_format' => 'json']);
+        $form->submit((string) json_encode([
+            'type' => 'doc',
+            'content' => [['type' => 'evilNode']],
+        ]));
+
+        self::assertFalse($form->isSynchronized());
+    }
+
+    public function testJsonRejectsMalformedDocuments(): void
+    {
+        $form = $this->factory->create(TextEditorType::class, null, ['output_format' => 'json']);
+        $form->submit('{not valid json');
+
+        self::assertFalse($form->isSynchronized());
+    }
+
+    public function testInvalidOutputFormatIsRejected(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $this->factory->create(TextEditorType::class, null, ['output_format' => 'pdf']);
+    }
+
+    public function testInvalidToolbarPresetIsRejected(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $this->factory->create(TextEditorType::class, null, ['toolbar' => 'fancy']);
+    }
+
+    public function testParentIsTextarea(): void
+    {
+        self::assertSame(TextareaType::class, (new TextEditorType(new HtmlSanitizerFactory()))->getParent());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function paragraph(string $text): array
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'text' => $text],
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Adds a secure, opinionated **Tiptap-based rich text editor form type** (`TextEditorType`) that any application can use to progressively enhance a standard textarea.

> Note: this branch also carries earlier commits (security/2FA config redesign, Rector config, doctrine/orm 3 support). The new work in this PR is the rich text editor described below.

## Rich text editor (`TextEditorType`)

- **`Form/Type/TextEditorType.php`** — extends `TextareaType` so it degrades gracefully without JavaScript. Auto-registered via the bundle's existing `services.php`. Options:
  - `output_format`: `html` (default, sanitized HTML string) or `json` (validated Tiptap/ProseMirror document)
  - `json_as_array`: store JSON as a decoded PHP array or a JSON string
  - `toolbar`: `minimal` / `default` / `full` preset
  - `allowed_tags`, `sanitizer`, `placeholder`, `editor_height`
- **`Form/TextEditor/ToolbarPreset.php`** — single source of truth mapping each preset to its toolbar buttons **and** sanitization allow-lists (HTML tags, ProseMirror nodes/marks, heading levels), so the UI and the server filter can't drift apart.
- **`Form/TextEditor/HtmlSanitizerFactory.php`** — opinionated `HtmlSanitizer` config (safe link schemes only, forced `rel="noopener noreferrer"`).
- **`Form/DataTransformer/SanitizeHtmlTransformer.php`** — sanitizes submitted HTML on the server (the real security boundary).
- **`Form/DataTransformer/JsonDocumentTransformer.php`** — validates/sanitizes Tiptap JSON, rejecting disallowed nodes/marks/heading levels and stripping unsafe link URLs.

## Frontend

- **`assets/controllers/text_editor_controller.ts`** — Stimulus controller mounting Tiptap (StarterKit + Link + Placeholder), wiring server-rendered toolbar buttons to editor commands, syncing content back into the hidden textarea, with Turbo-safe cleanup.
- **`assets/scss/_text-editor.scss`** — Tabler/Bootstrap-matched styling for the toolbar and `.ProseMirror` content area (imported in `platform.scss`).
- Tiptap v2 dependencies and the `text-editor` controller registered in `assets/package.json`.

## Twig, docs & deps

- `text_editor_widget` block added to the platform form theme.
- `docs/form-types/{index,text-editor}.md` (linked from `docs/index.md`), including how to register the form theme and render the output safely.
- `symfony/html-sanitizer` added to `composer.json`.

## Security

Sanitization happens in a Symfony data transformer — on the server, independent of the editor — so payloads that bypass the JavaScript editor cannot inject scripts, event handlers, or unsafe URL schemes. Links are restricted to `http`/`https`/`mailto` and forced to carry `rel="noopener noreferrer"`.

## Testing

- `TextEditorTypeTest` and `ToolbarPresetTest` — **20 tests / 51 assertions passing**, covering HTML sanitization, output formats, JSON validation/rejection, and option validation.
- PHPStan (level max) clean on the new code.

> The frontend bundler was not run in CI for this change (no Node toolchain available in the dev environment); run `cd assets && bun install && bun run build` to compile the controller and styles.
