### PR TITLE
feat(saas): free-plan lookup, expired-trial scan, and downgradeToFree()

### DIFF
--- a/src/Bundle/Saas/Exception/NoFreePlanConfiguredException.php
+++ b/src/Bundle/Saas/Exception/NoFreePlanConfiguredException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\SaasBundle\Exception;
+
+use RuntimeException;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use Throwable;
+use function sprintf;
+
+class NoFreePlanConfiguredException extends RuntimeException
+{
+    public function __construct(?Subscription $subscription = null, int $code = 0, ?Throwable $previous = null)
+    {
+        $message = $subscription instanceof Subscription
+            ? sprintf('Cannot downgrade subscription "%s": no active free plan is configured.', $subscription->getId()->toBase58())
+            : 'Cannot downgrade to the free plan: no active free plan is configured.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Bundle/Saas/Repository/PlanRepository.php
+++ b/src/Bundle/Saas/Repository/PlanRepository.php
@@ -75,6 +75,22 @@ class PlanRepository extends EntityRepository implements PlanRepositoryInterface
             ->getOneOrNullResult();
     }
 
+    public function findFree(): ?Plan
+    {
+        $result = $this->createQueryBuilder('p')
+            ->where('p.price = :price')
+            ->andWhere('p.planId = :planId')
+            ->andWhere('p.active = :active')
+            ->setParameter('price', 0)
+            ->setParameter('planId', '0')
+            ->setParameter('active', true)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof Plan ? $result : null;
+    }
+
     /**
      * @return list<Plan>
      */

--- a/src/Bundle/Saas/Repository/PlanRepositoryInterface.php
+++ b/src/Bundle/Saas/Repository/PlanRepositoryInterface.php
@@ -31,6 +31,13 @@ interface PlanRepositoryInterface
     public function findDefault(): ?Plan;
 
     /**
+     * Returns the active free plan (price 0, planId "0"), or null when no
+     * free plan is configured. Identifies the plan by its free-tier shape
+     * rather than the "default" flag.
+     */
+    public function findFree(): ?Plan;
+
+    /**
      * @return list<Plan>
      */
     public function findAllOrdered(): array;

--- a/src/Bundle/Saas/Repository/SubscriptionRepository.php
+++ b/src/Bundle/Saas/Repository/SubscriptionRepository.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace SolidWorx\Platform\SaasBundle\Repository;
 
+use DateTimeImmutable;
 use Doctrine\Persistence\ManagerRegistry;
 use Override;
 use SolidWorx\Platform\PlatformBundle\Repository\EntityRepository;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 
 /**
  * @template-extends EntityRepository<Subscription>
@@ -39,5 +41,23 @@ final class SubscriptionRepository extends EntityRepository implements Subscript
         assert($result === null || $result instanceof Subscription);
 
         return $result;
+    }
+
+    /**
+     * @return list<Subscription>
+     */
+    public function findExpiredTrials(DateTimeImmutable $now): array
+    {
+        /** @var list<Subscription> $subscriptions */
+        $subscriptions = $this->createQueryBuilder('s')
+            ->where('s.status = :status')
+            ->andWhere('s.endDate <= :now')
+            ->setParameter('status', SubscriptionStatus::TRIAL)
+            ->setParameter('now', $now)
+            ->orderBy('s.endDate', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $subscriptions;
     }
 }

--- a/src/Bundle/Saas/Repository/SubscriptionRepository.php
+++ b/src/Bundle/Saas/Repository/SubscriptionRepository.php
@@ -44,6 +44,13 @@ final class SubscriptionRepository extends EntityRepository implements Subscript
     }
 
     /**
+     * Returns expired trial subscriptions that are not externally billed.
+     *
+     * Externally-billed trials (those with a non-null/non-empty
+     * `subscriptionId`, see {@see Subscription::isExternallyBilled()}) are
+     * excluded: they are governed by the payment provider's own lifecycle
+     * and must never be auto-downgraded here.
+     *
      * @return list<Subscription>
      */
     public function findExpiredTrials(DateTimeImmutable $now): array
@@ -52,6 +59,7 @@ final class SubscriptionRepository extends EntityRepository implements Subscript
         $subscriptions = $this->createQueryBuilder('s')
             ->where('s.status = :status')
             ->andWhere('s.endDate <= :now')
+            ->andWhere("(s.subscriptionId IS NULL OR s.subscriptionId = '')")
             ->setParameter('status', SubscriptionStatus::TRIAL)
             ->setParameter('now', $now)
             ->orderBy('s.endDate', 'ASC')

--- a/src/Bundle/Saas/Repository/SubscriptionRepositoryInterface.php
+++ b/src/Bundle/Saas/Repository/SubscriptionRepositoryInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SolidWorx\Platform\SaasBundle\Repository;
 
+use DateTimeImmutable;
 use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 
 interface SubscriptionRepositoryInterface
@@ -24,4 +25,13 @@ interface SubscriptionRepositoryInterface
     public function findOneBy(array $criteria, array|null $orderBy = null): ?Subscription;
 
     public function save(object $entity, bool $flush = true): void;
+
+    /**
+     * Subscriptions still flagged TRIAL whose trial period has elapsed
+     * (endDate at or before $now). A lapsed trial's status is never flipped,
+     * so this date comparison is the source of truth.
+     *
+     * @return list<Subscription>
+     */
+    public function findExpiredTrials(DateTimeImmutable $now): array;
 }

--- a/src/Bundle/Saas/Subscription/SubscriptionManager.php
+++ b/src/Bundle/Saas/Subscription/SubscriptionManager.php
@@ -25,6 +25,7 @@ use SolidWorx\Platform\SaasBundle\Entity\Subscription;
 use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
 use SolidWorx\Platform\SaasBundle\Exception\ActiveSubscriptionPlanChangeException;
 use SolidWorx\Platform\SaasBundle\Exception\InvalidPlanException;
+use SolidWorx\Platform\SaasBundle\Exception\NoFreePlanConfiguredException;
 use SolidWorx\Platform\SaasBundle\Exception\TrialConfigurationException;
 use SolidWorx\Platform\SaasBundle\Integration\Options;
 use SolidWorx\Platform\SaasBundle\Integration\PaymentIntegrationInterface;
@@ -188,6 +189,29 @@ final readonly class SubscriptionManager implements SubscriptionProviderInterfac
         $subscription->setEndDate($endDate ?? CarbonImmutable::now('UTC')->addYears(100));
 
         $this->subscriptionRepository->save($subscription);
+    }
+
+    /**
+     * Auto-downgrade a subscription onto the free plan. Resolves the free
+     * plan itself, swaps it in (unless already free), and activates. This is
+     * the single semantic operation behind both the manual "choose free"
+     * flow and the expired-trial scheduler.
+     *
+     * @throws NoFreePlanConfiguredException
+     */
+    public function downgradeToFree(Subscription $subscription): void
+    {
+        $freePlan = $this->planRepository->findFree();
+
+        if (! $freePlan instanceof Plan) {
+            throw new NoFreePlanConfiguredException($subscription);
+        }
+
+        if ($subscription->getPlan()->getPlanId() !== $freePlan->getPlanId()) {
+            $this->changePlan($subscription, $freePlan);
+        }
+
+        $this->activate($subscription);
     }
 
     /**

--- a/tests/Bundle/Saas/Subscription/SubscriptionManagerDowngradeTest.php
+++ b/tests/Bundle/Saas/Subscription/SubscriptionManagerDowngradeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of SolidWorx Platform project.
+ *
+ * (c) Pierre du Plessis <open-source@solidworx.co>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace SolidWorx\Platform\Tests\Bundle\Saas\Subscription;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SolidWorx\Platform\SaasBundle\Entity\Plan;
+use SolidWorx\Platform\SaasBundle\Entity\Subscription;
+use SolidWorx\Platform\SaasBundle\Enum\SubscriptionStatus;
+use SolidWorx\Platform\SaasBundle\Exception\NoFreePlanConfiguredException;
+use SolidWorx\Platform\SaasBundle\Integration\PaymentIntegrationInterface;
+use SolidWorx\Platform\SaasBundle\Repository\PlanRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Repository\SubscriptionRepositoryInterface;
+use SolidWorx\Platform\SaasBundle\Subscription\SubscriptionManager;
+
+#[CoversClass(SubscriptionManager::class)]
+final class SubscriptionManagerDowngradeTest extends TestCase
+{
+    public function testDowngradeChangesPlanAndActivatesWhenNotAlreadyFree(): void
+    {
+        $free = $this->freePlan();
+        $plans = self::createStub(PlanRepositoryInterface::class);
+        $plans->method('findFree')->willReturn($free);
+
+        $subs = self::createMock(SubscriptionRepositoryInterface::class);
+        $subs->expects(self::atLeastOnce())->method('save');
+
+        $subscription = (new Subscription())->setPlan($this->paidPlan())->setStatus(SubscriptionStatus::TRIAL);
+
+        $this->manager($plans, $subs)->downgradeToFree($subscription);
+
+        self::assertSame($free, $subscription->getPlan());
+        self::assertSame(SubscriptionStatus::ACTIVE, $subscription->getStatus());
+    }
+
+    public function testDowngradeActivatesWithoutChangingPlanWhenAlreadyFree(): void
+    {
+        $free = $this->freePlan();
+        $plans = self::createStub(PlanRepositoryInterface::class);
+        $plans->method('findFree')->willReturn($free);
+
+        $subs = self::createStub(SubscriptionRepositoryInterface::class);
+
+        $subscription = (new Subscription())->setPlan($free)->setStatus(SubscriptionStatus::TRIAL);
+
+        $this->manager($plans, $subs)->downgradeToFree($subscription);
+
+        self::assertSame($free, $subscription->getPlan());
+        self::assertSame(SubscriptionStatus::ACTIVE, $subscription->getStatus());
+    }
+
+    public function testDowngradeThrowsWhenNoFreePlanConfigured(): void
+    {
+        $plans = self::createStub(PlanRepositoryInterface::class);
+        $plans->method('findFree')->willReturn(null);
+
+        $subscription = (new Subscription())->setPlan($this->paidPlan())->setStatus(SubscriptionStatus::TRIAL);
+
+        $this->expectException(NoFreePlanConfiguredException::class);
+
+        $this->manager($plans, self::createStub(SubscriptionRepositoryInterface::class))->downgradeToFree($subscription);
+    }
+
+    private function freePlan(): Plan
+    {
+        return (new Plan())->setName('Free')->setPlanId('0')->setPrice(0)->setActive(true);
+    }
+
+    private function paidPlan(): Plan
+    {
+        return (new Plan())->setName('Pro')->setPlanId('pro')->setPrice(1900)->setActive(true);
+    }
+
+    private function manager(PlanRepositoryInterface $plans, SubscriptionRepositoryInterface $subs): SubscriptionManager
+    {
+        return new SubscriptionManager($subs, $plans, self::createStub(PaymentIntegrationInterface::class));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the model-level building blocks for SolidInvoice's "auto-downgrade expired trials" feature. All changes are additive — no behavior change to existing methods.

## What's included (`src/Bundle/Saas`)

- **`PlanRepository::findFree()`** (+ interface) — resolves the Free plan by shape (`price === 0 && planId === '0' && active`) rather than the `default` flag, so a downgrade always lands on the actual free tier.
- **`SubscriptionRepository::findExpiredTrials(DateTimeImmutable $now)`** (+ interface) — returns `TRIAL` subscriptions past their `endDate`, **excluding externally-billed** ones (`subscriptionId` null/empty). Provider-managed (`on_trial`-webhook) trials are therefore never auto-downgraded, so external billing is never silently bypassed.
- **`SubscriptionManager::downgradeToFree(Subscription)`** — the single semantic operation behind the feature: resolve the free plan → `changePlan` (only when not already free) → `activate`. Throws `NoFreePlanConfiguredException` when no free plan exists (never downgrades onto a paid plan). Mirrors the existing "choose Free" flow and never invokes the payment integration.
- **`NoFreePlanConfiguredException`**.

## Testing

- Unit (`SubscriptionManagerDowngradeTest`): changes plan + activates when not already free; activates without a plan change when already free; throws when no free plan is configured. 3/3 passing.
- ECS clean; PHPStan **Level Max** clean on the changed files.

## Consumed by

The SolidInvoice `DowngradeExpiredTrialsCommand` (hourly scheduled task) — see the SolidInvoice/SolidInvoice PR for `feature/auto-downgrade-expired-trials`. Merge this and `composer update solidworx/platform` there.
